### PR TITLE
fix: Corresponding author

### DIFF
--- a/IAC_style.cls
+++ b/IAC_style.cls
@@ -144,8 +144,9 @@
     \whileboolexpr
       { test {\ifnumcomp{\value{authnum}}{<}{\theauthcount}} }%
       {\stepcounter{authnum}%
-		\ifnumcomp{\csuse{iac@iscorrespondingauthor\theauthnum}}{=}{1}{* Corresponding author}{}\par%
-		 \setcounter{authnum}{99}% exit the loop by invalidating the bool condition
+		\ifnumcomp{\csuse{iac@iscorrespondingauthor\theauthnum}}{=}{1}{
+      * Corresponding author
+      \setcounter{authnum}{99}}{}\par% % exit the loop by invalidating the bool condition
 		%\vskip 1.5ex%
 	  }
 %


### PR DESCRIPTION
The corresponding author note do not take effect when the corresponding author is not the first author.

The while loop is incorrectly exited after checking the first author.

![QQ截图20250721113017](https://github.com/user-attachments/assets/a9530c4e-8df5-4877-ba2a-b5c3c9d49f79)
